### PR TITLE
Use mul instead of unk for description language

### DIFF
--- a/data/phi1103/phi001/__cts__.xml
+++ b/data/phi1103/phi001/__cts__.xml
@@ -5,7 +5,7 @@
     
     <edition urn="urn:cts:latinLit:phi1103.phi001.lascivaroma-lat1" xml:lang="lat" workUrn="urn:cts:latinLit:phi1103.phi001">
         <label xml:lang="eng">Priapeia from Poeta Latini minores</label>
-        <description xml:lang="unk">Poeta Latini minores, ed. Aemilius Baehrens, Leipzig, Teubner, 1879</description>
+        <description xml:lang="mul">Poeta Latini minores, ed. Aemilius Baehrens, Leipzig, Teubner, 1879</description>
         <cpt:structured-metadata>
             <dct:source>https://archive.org/details/poetaelatinimino12baeh2</dct:source>
             <dct:contributor >Thibault Clérice</dct:contributor>


### PR DESCRIPTION
The code `unk` represents the [Enawené-Nawé](https://iso639-3.sil.org/code/unk) language, which is definitely not the language of the description in this document.

Similar descriptions in [other repositories](https://github.com/PerseusDL/canonical-greekLit/blob/803db1425219cd300d907e19c2cb958e6bd5cbbd/data/tlg0007/tlg072/__cts__.xml#L24) use `mul`.